### PR TITLE
EVC-85 Update repo url

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ environment:
   UAT_ENV: sas-evc-uat
   IMAGE_URL: 340268328991.dkr.ecr.eu-west-2.amazonaws.com
   IMAGE_REPO: sas/evc
-  GIT_REPO: UKHomeOffice/evc
+  GIT_REPO: UKHomeOffice/evisa-contact-form
   HOF_CONFIG: hof-services-config/E_Visa_Contact_Us
   NON_PROD_AVAILABILITY: Mon-Sun 08:00-23:00 Europe/London
   READY_FOR_TEST_DELAY: 20s

--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/UKHomeOffice/evc.git"
+    "url": "git+https://github.com/UKHomeOffice/evisa-contact-form.git"
   },
   "author": "HOF",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/UKHomeOffice/evc/issues"
+    "url": "https://github.com/UKHomeOffice/evisa-contact-form/issues"
   },
-  "homepage": "https://github.com/UKHomeOffice/evc#readme",
+  "homepage": "https://github.com/UKHomeOffice/evisa-contact-form#readme",
   "dependencies": {
     "accessible-autocomplete": "^2.0.4",
     "bl": "^6.0.12",


### PR DESCRIPTION
The EVC repo name was changed to `evisa-contact-form`, subsequently changing the repo url.

Search and replace was used to update the old url.